### PR TITLE
api_users_images: Handle empty images_process_list

### DIFF
--- a/api/api_users_images.py
+++ b/api/api_users_images.py
@@ -109,6 +109,9 @@ async def create_user_image_faceswap(
             images_process_list = process_images_multithread_bytes(
                 response)
             image_list = []
+            if images_process_list == []:
+                raise HTTPException(
+                    status_code=400, detail="Check your target or reference images possibly the faces are not aligned, sometimes it happens with images try with another one.")
             for key in images_process_list:
                 image_insert = image_model.Image(owner=authenticated["id"], name=f"faceswap_{random.randint(100000, 999999)}", description="Image generated from faceswap",
                                                  tags=["faceswap"], info={}, type="faceswap", image=key)


### PR DESCRIPTION
This commit adds error handling for the case when images_process_list is empty in the create_user_image_faceswap function. It raises an HTTPException with a descriptive message to guide the user in troubleshooting the issue.